### PR TITLE
Update forms to use GET for search and id-only actions

### DIFF
--- a/EIMS_SpringBoot/src/main/java/jp/co/trainocate/eims/controller/EmployeeController.java
+++ b/EIMS_SpringBoot/src/main/java/jp/co/trainocate/eims/controller/EmployeeController.java
@@ -56,10 +56,11 @@ public class EmployeeController {
 		return "search_result";
 	}
 
-	@GetMapping("/input")
-	public String showInputPage(EmployeeForm employeeForm) {
-		return "input";
-	}
+    @GetMapping("/input")
+    public String showInputPage(EmployeeForm employeeForm) {
+        return "input";
+    }
+
 
 	@PostMapping("/inputConfirm")
 	public String confirmRegistration(@Valid EmployeeForm employeeForm, BindingResult bindingResult, Model model) {

--- a/EIMS_SpringBoot/src/main/java/jp/co/trainocate/eims/controller/EmployeeController.java
+++ b/EIMS_SpringBoot/src/main/java/jp/co/trainocate/eims/controller/EmployeeController.java
@@ -27,10 +27,10 @@ public class EmployeeController {
 		return "index";
 	}
 
-	@GetMapping("/search")
-	public String showSearchPage() {
-		return "search";
-	}
+       @GetMapping("/search")
+       public String showSearchPage() {
+               return "search";
+       }
 
 	@GetMapping("/selectByEmpNo")
 	public String selectByEmpNo(Integer empno, Model model) {
@@ -56,10 +56,10 @@ public class EmployeeController {
 		return "search_result";
 	}
 
-	@GetMapping("/input")
-	public String showInputPage(EmployeeForm employeeForm) {
-		return "input";
-	}
+       @GetMapping("/input")
+       public String showInputPage(EmployeeForm employeeForm) {
+               return "input";
+       }
 
 	@PostMapping("/inputConfirm")
 	public String confirmRegistration(@Valid EmployeeForm employeeForm, BindingResult bindingResult, Model model) {
@@ -78,8 +78,8 @@ public class EmployeeController {
 		return "input_complete";
 	}
 
-	@GetMapping("/deleteConfirm/{empno}")
-	public String deleteConfirm(@PathVariable("empno") Integer empno, Model model) {
+       @GetMapping("/deleteConfirm/{empno}")
+       public String deleteConfirm(@PathVariable("empno") Integer empno, Model model) {
 		Employee employee = employeeService.findByEmployee(empno);
 		model.addAttribute("employee", employee);
 		return "delete_confirm";
@@ -91,8 +91,8 @@ public class EmployeeController {
 		return "delete_complete";
 	}
 
-	@GetMapping("/changeInput/{empno}")
-	public String changeInput(@PathVariable("empno") int empno, EmployeeForm employeeForm, Model model) {
+       @GetMapping("/changeInput/{empno}")
+       public String changeInput(@PathVariable("empno") int empno, EmployeeForm employeeForm, Model model) {
 		employeeForm = employeeService.findByEmpNoAndCopyToEmployeeForm(empno, employeeForm);
 		return "change";
 	}

--- a/EIMS_SpringBoot/src/main/resources/templates/change_confirm.html
+++ b/EIMS_SpringBoot/src/main/resources/templates/change_confirm.html
@@ -54,7 +54,6 @@
                 <div class="col-sm-10 offset-sm-2">
                     <button type="submit" class="btn btn-primary">変更確定</button>
                     <button type="button" class="btn btn-secondary" onclick="history.back()">修正</button>
-                    <button type="button" class="btn btn-danger" onclick="location.href='/search'">取消</button>
                 </div>
             </div>
             <input type="hidden" th:field="*{empno}" />
@@ -65,6 +64,13 @@
             <input type="hidden" th:field="*{gender}" />
             <input type="hidden" th:field="*{deptno}" />
             <input type="hidden" th:field="*{password}" />
+        </form>
+        <form th:action="@{/search}" method="get" class="mt-2">
+            <div class="form-group row">
+                <div class="col-sm-10 offset-sm-2">
+                    <button type="submit" class="btn btn-danger">取消</button>
+                </div>
+            </div>
         </form>
     </div>
 </body>

--- a/EIMS_SpringBoot/src/main/resources/templates/delete_confirm.html
+++ b/EIMS_SpringBoot/src/main/resources/templates/delete_confirm.html
@@ -49,7 +49,6 @@
             <div class="form-group row">
                 <div class="col-sm-10 offset-sm-2">
                     <button type="submit" class="btn btn-danger">削除確定</button>
-                    <button type="button" class="btn btn-secondary" onclick="history.back(-1)">取消</button>
                 </div>
             </div>
             <input type="hidden" th:field="*{empno}" />
@@ -59,7 +58,14 @@
             <input type="hidden" th:field="*{fkana}" />
             <input type="hidden" th:field="*{gender}" />
             <input type="hidden" th:field="*{deptno}" />
-        
+
+        </form>
+        <form th:action="@{/search}" method="get" class="mt-2">
+            <div class="form-group row">
+                <div class="col-sm-10 offset-sm-2">
+                    <button type="submit" class="btn btn-secondary">取消</button>
+                </div>
+            </div>
         </form>
     </div>
 </body>

--- a/EIMS_SpringBoot/src/main/resources/templates/input_confirm.html
+++ b/EIMS_SpringBoot/src/main/resources/templates/input_confirm.html
@@ -49,7 +49,7 @@
             <div class="form-group row">
                 <div class="col-sm-10 offset-sm-2">
                     <button type="submit" class="btn btn-primary">登録確定</button>
-                    <button type="button" class="btn btn-secondary" onclick="history.back()">修正</button>
+                    <button type="submit" class="btn btn-secondary" th:formaction="@{/input}" formmethod="get">修正</button>
                     <button type="button" class="btn btn-danger" onclick="location.href='/input'">取消</button>
                 </div>
             </div>

--- a/EIMS_SpringBoot/src/main/resources/templates/input_confirm.html
+++ b/EIMS_SpringBoot/src/main/resources/templates/input_confirm.html
@@ -50,7 +50,6 @@
                 <div class="col-sm-10 offset-sm-2">
                     <button type="submit" class="btn btn-primary">登録確定</button>
                     <button type="button" class="btn btn-secondary" onclick="history.back()">修正</button>
-                    <button type="button" class="btn btn-danger" onclick="location.href='/input'">取消</button>
                 </div>
             </div>
             <input type="hidden" th:field="*{lname}" />
@@ -60,6 +59,13 @@
             <input type="hidden" th:field="*{gender}" />
             <input type="hidden" th:field="*{deptno}" />
             <input type="hidden" th:field="*{password}" />
+        </form>
+        <form th:action="@{/input}" method="get" class="mt-2">
+            <div class="form-group row">
+                <div class="col-sm-10 offset-sm-2">
+                    <button type="submit" class="btn btn-danger">取消</button>
+                </div>
+            </div>
         </form>
     </div>
 </body>

--- a/EIMS_SpringBoot/src/main/resources/templates/search_result.html
+++ b/EIMS_SpringBoot/src/main/resources/templates/search_result.html
@@ -39,14 +39,14 @@
 							<td th:text="${employee.department.deptname}"></td>
 							<td>
 								<div class="btn-group" role="group">
-									<form th:action="@{/changeInput/}+ ${employee.empno}" method="get"
-										style="display:inline;">
-										<button type="submit" class="btn btn-primary">変更</button>
-									</form>
-									<form th:action="@{/deleteConfirm/}+ ${employee.empno}" method="get"
-										style="display:inline;">
-										<button type="submit" class="btn btn-danger">削除</button>
-									</form>
+                                                                        <form th:action="@{/changeInput/}+ ${employee.empno}" method="get"
+                                                                               style="display:inline;">
+                                                                               <button type="submit" class="btn btn-primary">変更</button>
+                                                                       </form>
+                                                                        <form th:action="@{/deleteConfirm/}+ ${employee.empno}" method="get"
+                                                                               style="display:inline;">
+                                                                               <button type="submit" class="btn btn-danger">削除</button>
+                                                                       </form>
 								</div>
 							</td>
 						</tr>


### PR DESCRIPTION
## Summary
- revert search and input routes back to GET-only
- revert delete and update routes to GET when only an ID is passed
- update cancel buttons to submit GET forms
- adjust search result forms back to GET

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684fdde6bcf88321a48f1ea3d585fc4f