### PR TITLE
Remove th:if from password error divs

### DIFF
--- a/EIMS_SpringBoot/src/main/resources/templates/change.html
+++ b/EIMS_SpringBoot/src/main/resources/templates/change.html
@@ -66,7 +66,7 @@
                 <tr>
                     <td>パスワード</td>
                     <td><input type="text" name = "password" class="form-control" /></td>
-                    <td><div th:if="${#fields.hasErrors('password')}" th:errors="*{password}" class="text-danger"></div></td>
+                    <td><div th:errors="*{password}" class="text-danger"></div></td>
                 </tr>
             </table>
             <button type="submit" class="btn btn-primary">変更</button>

--- a/EIMS_SpringBoot/src/main/resources/templates/input.html
+++ b/EIMS_SpringBoot/src/main/resources/templates/input.html
@@ -62,7 +62,7 @@
                 <tr>
                     <td>パスワード</td>
                     <td><input type="password" th:field="*{password}" class="form-control" /></td>
-                    <td><div th:if="${#fields.hasErrors('password')}" th:errors="*{password}" class="text-danger"></div></td>
+                    <td><div th:errors="*{password}" class="text-danger"></div></td>
                 </tr>
             </table>
             <div class="form-group row">


### PR DESCRIPTION
## Summary
- leave the `<div>` for password errors rendered even when empty by removing `th:if`

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ff82778288321817f545e4788bf41