### PR TITLE
Add EmployeeController tests

### DIFF
--- a/EIMS_SpringBoot/pom.xml
+++ b/EIMS_SpringBoot/pom.xml
@@ -40,10 +40,10 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
-			<groupId>com.mysql</groupId>
-			<artifactId>mysql-connector-j</artifactId>
-			<scope>runtime</scope>
-		</dependency>
+    <groupId>com.mysql</groupId>
+    <artifactId>mysql-connector-j</artifactId>
+    <version>8.4.0</version>
+</dependency>
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>

--- a/EIMS_SpringBoot/src/main/java/jp/co/trainocate/eims/controller/EmployeeController.java
+++ b/EIMS_SpringBoot/src/main/java/jp/co/trainocate/eims/controller/EmployeeController.java
@@ -2,7 +2,6 @@ package jp.co.trainocate.eims.controller;
 
 import java.util.List;
 
-import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -109,12 +108,11 @@ public class EmployeeController {
 
     /** 新規社員を登録する */
     @PostMapping("/saveEmployee")
-    public String saveEmployee(EmployeeForm employeeForm, ModelMapper modelMapper, Model model) {
+    public String saveEmployee(EmployeeForm employeeForm, Model model) {
                 // 画面から受け取ったフォームオブジェクトをエンティティへ変換
-                Employee employee = modelMapper.map(employeeForm, Employee.class);
                 // DB へ保存し、採番された社員番号を取得
-                employee = employeeService.saveEmployee(employee);
-                employeeForm.setEmpno(employee.getEmpno());
+                Employee newEmployee = employeeService.saveEmployee(employeeForm);
+                employeeForm.setEmpno(newEmployee.getEmpno());
                 model.addAttribute("department", departmentService.findById(employeeForm.getDeptno()));
                 // 完了画面へ遷移
                 return "input_complete";
@@ -165,10 +163,9 @@ public class EmployeeController {
 
     /** 社員情報を更新する */
     @PostMapping("/changeEmployee")
-    public String changeEmployee(EmployeeForm employeeForm, ModelMapper modelMapper, Model model) {
+    public String changeEmployee(EmployeeForm employeeForm, Model model) {
                 // 入力された内容でエンティティを生成し保存
-                Employee employee = modelMapper.map(employeeForm, Employee.class);
-                employee = employeeService.saveEmployee(employee);
+                employeeService.saveEmployee(employeeForm);
                 model.addAttribute("department", departmentService.findById(employeeForm.getDeptno()));
                 // 更新完了後は完了画面へ
                 return "change_complete";

--- a/EIMS_SpringBoot/src/main/java/jp/co/trainocate/eims/entity/Department.java
+++ b/EIMS_SpringBoot/src/main/java/jp/co/trainocate/eims/entity/Department.java
@@ -17,7 +17,7 @@ import lombok.Data;
 @Data
 @Table(name = "department")
 public class Department {
-    // 主キーの部署番号。自動採番を使用
+    // 主キーの部署番号。
     @Id
     /** 部署番号 */
     private Integer deptno;
@@ -38,11 +38,7 @@ public class Department {
         this.deptname = deptname;
     }
     
- // ★追加：部門名を同時設定するコンストラクタ
-    public Department(String deptname) {
-        this.deptname = deptname;
-    }
-
+ 
     // ★JPA用のデフォルトコンストラクタ（必須）
     public Department() {}
 }

--- a/EIMS_SpringBoot/src/main/java/jp/co/trainocate/eims/entity/Department.java
+++ b/EIMS_SpringBoot/src/main/java/jp/co/trainocate/eims/entity/Department.java
@@ -32,4 +32,14 @@ public class Department {
     /** 部署に所属する社員一覧 */
     @OneToMany(mappedBy = "department")
     private List<Employee> employees;
+    
+
+    // ★追加：部門番号・部門名を同時設定するコンストラクタ
+    public Department(Integer deptno, String deptname) {
+        this.deptno = deptno;
+        this.deptname = deptname;
+    }
+
+    // ★JPA用のデフォルトコンストラクタ（必須）
+    public Department() {}
 }

--- a/EIMS_SpringBoot/src/main/java/jp/co/trainocate/eims/entity/Department.java
+++ b/EIMS_SpringBoot/src/main/java/jp/co/trainocate/eims/entity/Department.java
@@ -8,8 +8,6 @@ import java.util.List;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
@@ -21,7 +19,6 @@ import lombok.Data;
 public class Department {
     // 主キーの部署番号。自動採番を使用
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     /** 部署番号 */
     private Integer deptno;
 	
@@ -36,7 +33,13 @@ public class Department {
 
     // ★追加：部門番号・部門名を同時設定するコンストラクタ
     public Department(Integer deptno, String deptname) {
-        this.deptno = deptno;
+        super();
+    	this.deptno = deptno;
+        this.deptname = deptname;
+    }
+    
+ // ★追加：部門名を同時設定するコンストラクタ
+    public Department(String deptname) {
         this.deptname = deptname;
     }
 

--- a/EIMS_SpringBoot/src/main/java/jp/co/trainocate/eims/entity/Employee.java
+++ b/EIMS_SpringBoot/src/main/java/jp/co/trainocate/eims/entity/Employee.java
@@ -85,18 +85,7 @@ public class Employee {
 		this.deptno = deptno;
 	}
 
-	// ★追加：Id以外の全主要フィールドを同時設定するコンストラクタ。departmentを初期化するパターン
-		public Employee(String lname, String fname, String lkana, String fkana,
-				String password, Integer gender, Integer deptno) {
-			super();
-			this.lname = lname;
-			this.fname = fname;
-			this.lkana = lkana;
-			this.fkana = fkana;
-			this.password = password;
-			this.gender = gender;
-			this.deptno = deptno;
-		}
+	
 		
 	// ★JPA用のデフォルトコンストラクタ（必須）
 	public Employee() {

--- a/EIMS_SpringBoot/src/main/java/jp/co/trainocate/eims/entity/Employee.java
+++ b/EIMS_SpringBoot/src/main/java/jp/co/trainocate/eims/entity/Employee.java
@@ -50,7 +50,7 @@ public class Employee {
 
 	/** 所属部署 */
 	@ManyToOne
-	@JoinColumn(name = "deptno", referencedColumnName = "deptno", insertable = false, updatable = false)
+	@JoinColumn(name = "deptno", insertable = false, updatable = false)
 	private Department department;
 
 	/** 部署番号 (外部キー) */
@@ -60,6 +60,7 @@ public class Employee {
 	// ★追加：全主要フィールドを同時設定するコンストラクタ。departmentを初期化するパターン
 	public Employee(Integer empno, String lname, String fname, String lkana, String fkana,
 			String password, Integer gender, Department department) {
+		super();
 		this.empno = empno;
 		this.lname = lname;
 		this.fname = fname;
@@ -73,6 +74,7 @@ public class Employee {
 	// ★追加：全主要同時設定するコンストラクタ。deptnoを初期化するパターン
 	public Employee(Integer empno, String lname, String fname, String lkana, String fkana,
 			String password, Integer gender, Integer deptno) {
+		super();
 		this.empno = empno;
 		this.lname = lname;
 		this.fname = fname;
@@ -83,6 +85,19 @@ public class Employee {
 		this.deptno = deptno;
 	}
 
+	// ★追加：Id以外の全主要フィールドを同時設定するコンストラクタ。departmentを初期化するパターン
+		public Employee(String lname, String fname, String lkana, String fkana,
+				String password, Integer gender, Integer deptno) {
+			super();
+			this.lname = lname;
+			this.fname = fname;
+			this.lkana = lkana;
+			this.fkana = fkana;
+			this.password = password;
+			this.gender = gender;
+			this.deptno = deptno;
+		}
+		
 	// ★JPA用のデフォルトコンストラクタ（必須）
 	public Employee() {
 	}

--- a/EIMS_SpringBoot/src/main/java/jp/co/trainocate/eims/entity/Employee.java
+++ b/EIMS_SpringBoot/src/main/java/jp/co/trainocate/eims/entity/Employee.java
@@ -18,43 +18,72 @@ import lombok.Data;
 @Data
 @Table(name = "employee")
 public class Employee {
-    // 主キーに自動採番を使用
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    /** 社員番号 */
-    private Integer empno;
-	
-    /** 氏 */
-    @Column(length = 20, nullable = false)
-    private String lname;
-	
-    /** 名 */
-    @Column(length = 20, nullable = false)
-    private String fname;
-	
-    /** 氏(カナ) */
-    @Column(length = 50, nullable = false)
-    private String lkana;
-	
-    /** 名(カナ) */
-    @Column(length = 50, nullable = false)
-    private String fkana;
-	
-    /** パスワード */
-    @Column(length = 8, nullable = false)
-    private String password;
-	
-    /** 性別 1:男性 2:女性 */
-    @Column(nullable = false)
-    private Integer gender;
-	
-    /** 部署番号 (外部キー) */
-    @Column(name="deptno")
-    private Integer deptno;
-	
-    /** 所属部署 */
-    @ManyToOne
-    @JoinColumn(name = "deptno", referencedColumnName = "deptno", insertable = false, updatable = false)
-    private Department department;
-	
+	// 主キーに自動採番を使用
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	/** 社員番号 */
+	private Integer empno;
+
+	/** 氏 */
+	@Column(length = 20, nullable = false)
+	private String lname;
+
+	/** 名 */
+	@Column(length = 20, nullable = false)
+	private String fname;
+
+	/** 氏(カナ) */
+	@Column(length = 50, nullable = false)
+	private String lkana;
+
+	/** 名(カナ) */
+	@Column(length = 50, nullable = false)
+	private String fkana;
+
+	/** パスワード */
+	@Column(length = 30, nullable = false)
+	private String password;
+
+	/** 性別 1:男性 2:女性 */
+	@Column(nullable = false)
+	private Integer gender;
+
+	/** 所属部署 */
+	@ManyToOne
+	@JoinColumn(name = "deptno", referencedColumnName = "deptno", insertable = false, updatable = false)
+	private Department department;
+
+	/** 部署番号 (外部キー) */
+	@Column(name = "deptno")
+	private Integer deptno;
+
+	// ★追加：全主要フィールドを同時設定するコンストラクタ。departmentを初期化するパターン
+	public Employee(Integer empno, String lname, String fname, String lkana, String fkana,
+			String password, Integer gender, Department department) {
+		this.empno = empno;
+		this.lname = lname;
+		this.fname = fname;
+		this.lkana = lkana;
+		this.fkana = fkana;
+		this.password = password;
+		this.gender = gender;
+		this.department = department;
+	}
+
+	// ★追加：全主要同時設定するコンストラクタ。deptnoを初期化するパターン
+	public Employee(Integer empno, String lname, String fname, String lkana, String fkana,
+			String password, Integer gender, Integer deptno) {
+		this.empno = empno;
+		this.lname = lname;
+		this.fname = fname;
+		this.lkana = lkana;
+		this.fkana = fkana;
+		this.password = password;
+		this.gender = gender;
+		this.deptno = deptno;
+	}
+
+	// ★JPA用のデフォルトコンストラクタ（必須）
+	public Employee() {
+	}
 }

--- a/EIMS_SpringBoot/src/main/java/jp/co/trainocate/eims/form/EmployeeForm.java
+++ b/EIMS_SpringBoot/src/main/java/jp/co/trainocate/eims/form/EmployeeForm.java
@@ -37,7 +37,7 @@ public class EmployeeForm {
 
     /** パスワード */
     @NotBlank(message = "パスワードは必須項目です")
-    @Size(max = 8, message = "パスワードは8文字以内で入力してください")
+    @Size(min = 8, message = "パスワードは8文字以上で入力してください")
     private String password;
 
     /** 性別 1:男性 2:女性 */
@@ -45,5 +45,6 @@ public class EmployeeForm {
     private Integer gender;
 
     /** 部署番号 */
+    @NotNull(message = "部署の選択は必須です")
     private Integer deptno;
 }

--- a/EIMS_SpringBoot/src/main/java/jp/co/trainocate/eims/service/EmployeeService.java
+++ b/EIMS_SpringBoot/src/main/java/jp/co/trainocate/eims/service/EmployeeService.java
@@ -36,8 +36,8 @@ public interface EmployeeService {
      * @param employee 保存対象のエンティティ
      * @return 保存後のエンティティ
      */
-    Employee saveEmployee(Employee employee);
-
+    //Employee saveEmployee(Employee employee);
+    Employee saveEmployee(EmployeeForm form);  
     /**
      * 社員番号を指定して 1 件の従業員を取得します。
      * @param empno 社員番号

--- a/EIMS_SpringBoot/src/main/java/jp/co/trainocate/eims/service/EmployeeServiceImpl.java
+++ b/EIMS_SpringBoot/src/main/java/jp/co/trainocate/eims/service/EmployeeServiceImpl.java
@@ -18,23 +18,23 @@ import lombok.RequiredArgsConstructor;
  */
 public class EmployeeServiceImpl implements EmployeeService {
 
-        /** EmployeeRepository のDI */
-        @Autowired
-        private final EmployeeRepository employeeRepository;
+	/** EmployeeRepository のDI */
+	@Autowired
+	private final EmployeeRepository employeeRepository;
 
-        /** 社員番号で検索 */
-        @Override
-        public List<Employee> findByEmpNo(int empno) {
-                // Repository を利用して主キー検索を実行
-                return employeeRepository.findByempno(empno);
-        }
+	/** 社員番号で検索 */
+	@Override
+	public List<Employee> findByEmpNo(int empno) {
+		// Repository を利用して主キー検索を実行
+		return employeeRepository.findByempno(empno);
+	}
 
-        /** 氏名で検索 */
-        @Override
-        public List<Employee> findByEmpName(String keyword) {
-                // あいまい検索のためキーワードを % で挟む
-                return employeeRepository.findByEmpNameLike("%" + keyword + "%");
-        }
+	/** 氏名で検索 */
+	@Override
+	public List<Employee> findByEmpName(String keyword) {
+		// あいまい検索のためキーワードを % で挟む
+		return employeeRepository.findByEmpNameLike("%" + keyword + "%");
+	}
 
 	//JPQLを使わないパターン
 	/*public List<Employee> findByEmpName(String keyword) {
@@ -42,50 +42,64 @@ public class EmployeeServiceImpl implements EmployeeService {
 		return employeeRepository.findByLnameLikeOrFnameLikeOrLkanaLikeOrFkanaLike(likeKeyword, likeKeyword,
 				likeKeyword, likeKeyword);
 	}*/
-        /** 部署番号で検索 */
-        @Override
-        public List<Employee> findByDeptNo(Integer deptno) {
-                // 部署番号を条件に所属する従業員を取得
-                return employeeRepository.findByDepartmentDeptno(deptno);
-        }
+	/** 部署番号で検索 */
+	@Override
+	public List<Employee> findByDeptNo(Integer deptno) {
+		// 部署番号を条件に所属する従業員を取得
+		return employeeRepository.findByDepartmentDeptno(deptno);
+	}
 
-    /** 従業員を保存 */
-    @Override
-    public Employee saveEmployee(Employee employee) {
-        // save メソッドは新規登録と更新の両方に利用可能
-        return employeeRepository.save(employee);
-    }
 
-        /** 社員番号をキーに従業員を取得 */
-        @Override
-        public Employee findByEmployee(int empno) {
-                // Optional を取得し、中身を取り出す
-                return employeeRepository.findById(empno).get();
-        }
+	/** 社員番号をキーに従業員を取得 */
+	@Override
+	public Employee findByEmployee(int empno) {
+		// Optional を取得し、中身を取り出す
+		return employeeRepository.findById(empno).get();
+	}
 
-        /** 従業員を削除 */
-        @Override
-        public void deleteEmployeeById(Integer empno) {
-                // 指定された社員番号で削除処理を実行
-                employeeRepository.deleteById(empno);
-        }
+	/** 従業員を削除 */
+	@Override
+	public void deleteEmployeeById(Integer empno) {
+		// 指定された社員番号で削除処理を実行
+		employeeRepository.deleteById(empno);
+	}
 
-        /**
-         * 社員番号で検索し、結果を EmployeeForm にコピーして返却。
-         */
-        @Override
-        public EmployeeForm findByEmpNoAndCopyToEmployeeForm(int empno, EmployeeForm employeeForm) {
-                // DB から従業員を取得
-                Employee employee = employeeRepository.findById(empno).get();
-                // 取得したエンティティの内容をフォームにコピー
-                employeeForm.setEmpno(employee.getEmpno());
-                employeeForm.setFname(employee.getFname());
-                employeeForm.setLname(employee.getLname());
-                employeeForm.setFkana(employee.getFkana());
-                employeeForm.setLkana(employee.getLkana());
-                employeeForm.setGender(employee.getGender());
-                employeeForm.setDeptno(employee.getDeptno());
-                employeeForm.setPassword(employee.getPassword());
-                return employeeForm;
-        }
+	/**
+	 * 社員番号で検索し、結果を EmployeeForm にコピーして返却。
+	 */
+	@Override
+	public EmployeeForm findByEmpNoAndCopyToEmployeeForm(int empno, EmployeeForm employeeForm) {
+		// DB から従業員を取得
+		Employee employee = employeeRepository.findById(empno).get();
+		// 取得したエンティティの内容をフォームにコピー
+		employeeForm.setEmpno(employee.getEmpno());
+		employeeForm.setFname(employee.getFname());
+		employeeForm.setLname(employee.getLname());
+		employeeForm.setFkana(employee.getFkana());
+		employeeForm.setLkana(employee.getLkana());
+		employeeForm.setGender(employee.getGender());
+		employeeForm.setDeptno(employee.getDeptno());
+		employeeForm.setPassword(employee.getPassword());
+		return employeeForm;
+	}
+
+	/**
+	 * 登録・更新処理メソッド
+	 * Form内のデータをEntityへコピーし、登録又は更新後の該当データを返却します。
+	 */
+	@Override
+	public Employee saveEmployee(EmployeeForm f) {
+		Employee e = new Employee();
+		if (f.getEmpno() != null) {
+			e.setEmpno(f.getEmpno());
+		} // 更新時に保持
+		e.setLname(f.getLname());
+		e.setFname(f.getFname());
+		e.setLkana(f.getLkana());
+		e.setFkana(f.getFkana());
+		e.setPassword(f.getPassword());
+		e.setGender(f.getGender());
+		e.setDeptno(f.getDeptno()); // 外部キー列を設定（departmentは不要）
+		return employeeRepository.save(e);
+	}
 }

--- a/EIMS_SpringBoot/src/main/resources/application.properties
+++ b/EIMS_SpringBoot/src/main/resources/application.properties
@@ -3,5 +3,5 @@ spring.thymeleaf.cache=false
 spring.datasource.url=jdbc:mysql://localhost/eimsdb?serverTimezone=Asia/Tokyo
 spring.datasource.username=eimsuser
 spring.datasource.password=eimspass
-spring.jpa.hibernate.ddl-auto=update
+
 spring.jpa.show-sql=true

--- a/EIMS_SpringBoot/src/test/java/jp/co/trainocate/eims/controller/EmployeeControllerTest.java
+++ b/EIMS_SpringBoot/src/test/java/jp/co/trainocate/eims/controller/EmployeeControllerTest.java
@@ -1,6 +1,10 @@
 package jp.co.trainocate.eims.controller;
-
+//Hamcrest はワイルドカードをやめ、必要なものだけ
 import static org.hamcrest.Matchers.*;
+//Mockito 側は個別に
+import static org.mockito.ArgumentMatchers.any;
+//※ Mockito のワイルドカード import（import static org.mockito.Mockito.*;）は使わない
+//when/verify は個別 import する
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -19,6 +23,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import jp.co.trainocate.eims.entity.Department;
 import jp.co.trainocate.eims.entity.Employee;
+import jp.co.trainocate.eims.form.EmployeeForm;
 import jp.co.trainocate.eims.service.DepartmentService;
 import jp.co.trainocate.eims.service.EmployeeService;
 
@@ -104,7 +109,10 @@ class EmployeeControllerTest {
 	@Test
 	@DisplayName("氏名キーワード検索：「田」の検索結果を search_result に表示")
 	void testSelectByEmpName_ReturnsResult() throws Exception {
-		Mockito.when(employeeService.findByEmpName("田")).thenReturn(empList);
+		List<Employee> mockEmployees = List.of(
+				new Employee(10001, "山田", "陽翔", "ヤマダ", "ヒナタ", "password", 1, deptList.get(0)),
+				new Employee(10002, "中田", "結衣", "タナカ", "ユイ", "password", 2, deptList.get(0)));
+		Mockito.when(employeeService.findByEmpName("田")).thenReturn(mockEmployees);
 
 		mockMvc.perform(get("/selectByEmpName").param("keyword", "田"))
 				.andExpect(status().isOk())
@@ -211,7 +219,17 @@ class EmployeeControllerTest {
 	@Test
 	@DisplayName("登録実行：保存して input_complete を返す（ModelMapper不使用）")
 	void testSaveEmployee_SavesAndReturnsComplete() throws Exception {
-		Mockito.when(departmentService.findById(100)).thenReturn(deptList.get(0));
+		when(departmentService.findById(100)).thenReturn(new Department(100, "人事部"));
+
+		// 引数はBinderが作る別インスタンスなので any(EmployeeForm.class) でマッチさせる
+		when(employeeService.saveEmployee(any(EmployeeForm.class))).thenAnswer(inv -> {
+			EmployeeForm f = inv.getArgument(0);
+			// 必要ならここで f の中身をアサートしてもOK
+			Employee e = new Employee();
+			e.setEmpno(20001); // 採番想定
+			e.setDeptno(f.getDeptno()); // 部門も返しておくと後続が自然
+			return e;
+		});
 
 		mockMvc.perform(post("/saveEmployee")
 				.param("lname", "山田")
@@ -224,8 +242,7 @@ class EmployeeControllerTest {
 				.andExpect(status().isOk())
 				.andExpect(view().name("input_complete"))
 				.andExpect(model().attributeExists("department"))
-				.andExpect(model().attribute("department", hasProperty("deptname",
-						is("人事部"))));
+				.andExpect(model().attribute("department", hasProperty("deptname", is("人事部"))));
 
 	}
 
@@ -246,7 +263,6 @@ class EmployeeControllerTest {
 	@Test
 	@DisplayName("削除実行：削除して delete_complete を返す")
 	void testDeleteEmployee_PerformsDeleteAndReturnsComplete() throws Exception {
-		Mockito.when(employeeService.findByEmployee(10001)).thenReturn(empList.get(0));
 
 		mockMvc.perform(post("/deleteEmployee")
 				.param("empno", "10001")
@@ -258,9 +274,7 @@ class EmployeeControllerTest {
 				.param("gender", "1")
 				.param("deptno", "100"))
 				.andExpect(status().isOk())
-				.andExpect(view().name("delete_complete"))
-				.andExpect(model().attributeExists("employee"))
-				.andExpect(model().attribute("employee", hasProperty("empno", is(10001))));
+				.andExpect(view().name("delete_complete"));
 
 	}
 

--- a/EIMS_SpringBoot/src/test/java/jp/co/trainocate/eims/controller/EmployeeControllerTest.java
+++ b/EIMS_SpringBoot/src/test/java/jp/co/trainocate/eims/controller/EmployeeControllerTest.java
@@ -1,0 +1,295 @@
+package jp.co.trainocate.eims.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import jp.co.trainocate.eims.entity.Department;
+import jp.co.trainocate.eims.entity.Employee;
+import jp.co.trainocate.eims.form.EmployeeForm;
+import jp.co.trainocate.eims.service.DepartmentService;
+import jp.co.trainocate.eims.service.EmployeeService;
+
+@WebMvcTest(EmployeeController.class)
+class EmployeeControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private EmployeeService employeeService;
+
+    @MockBean
+    private DepartmentService departmentService;
+
+    @MockBean
+    private ModelMapper modelMapper;
+
+    private Department createDepartment(int deptno, String name) {
+        Department dept = new Department();
+        dept.setDeptno(deptno);
+        dept.setDeptname(name);
+        return dept;
+    }
+
+    private Employee createEmployee(int empno, int deptno) {
+        Employee emp = new Employee();
+        emp.setEmpno(empno);
+        emp.setDeptno(deptno);
+        return emp;
+    }
+
+    @Test
+    void index_ReturnsIndexView() throws Exception {
+        mockMvc.perform(get("/index"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("index"));
+    }
+
+    @Test
+    void showSearchPage_ReturnsSearchWithDepartments() throws Exception {
+        List<Department> departments = List.of(createDepartment(1, "Sales"));
+        when(departmentService.findAll()).thenReturn(departments);
+
+        mockMvc.perform(get("/search"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("search"))
+                .andExpect(model().attribute("departments", departments));
+    }
+
+    @Test
+    void selectByEmpNo_WithParam_ReturnsResult() throws Exception {
+        List<Employee> employees = List.of(createEmployee(1, 1));
+        when(employeeService.findByEmpNo(1)).thenReturn(employees);
+
+        mockMvc.perform(get("/selectByEmpNo").param("empno", "1"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("search_result"))
+                .andExpect(model().attribute("employees", employees));
+    }
+
+    @Test
+    void selectByEmpNo_NoParam_ReturnsSearch() throws Exception {
+        mockMvc.perform(get("/selectByEmpNo"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("search"));
+    }
+
+    @Test
+    void selectByEmpName_ReturnsResult() throws Exception {
+        List<Employee> employees = List.of(createEmployee(1, 1));
+        when(employeeService.findByEmpName("foo")).thenReturn(employees);
+
+        mockMvc.perform(get("/selectByEmpName").param("keyword", "foo"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("search_result"))
+                .andExpect(model().attribute("employees", employees));
+    }
+
+    @Test
+    void selectByDeptNo_ReturnsResult() throws Exception {
+        List<Employee> employees = List.of(createEmployee(1, 1));
+        when(employeeService.findByDeptNo(1)).thenReturn(employees);
+
+        mockMvc.perform(get("/selectByDeptNo").param("deptno", "1"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("search_result"))
+                .andExpect(model().attribute("employees", employees));
+    }
+
+    @Test
+    void showInputPage_ReturnsInputWithDepartments() throws Exception {
+        List<Department> departments = List.of(createDepartment(1, "Sales"));
+        when(departmentService.findAll()).thenReturn(departments);
+
+        mockMvc.perform(get("/input"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("input"))
+                .andExpect(model().attribute("departments", departments));
+    }
+
+    @Test
+    void confirmRegistration_WhenValidationFails_ReturnsInput() throws Exception {
+        List<Department> departments = List.of(createDepartment(1, "Sales"));
+        when(departmentService.findAll()).thenReturn(departments);
+
+        mockMvc.perform(post("/inputConfirm")
+                .param("lname", "")
+                .param("fname", "Taro")
+                .param("lkana", "ヤマダ")
+                .param("fkana", "タロウ")
+                .param("password", "pass")
+                .param("gender", "1")
+                .param("deptno", "1"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("input"))
+                .andExpect(model().attribute("departments", departments));
+    }
+
+    @Test
+    void confirmRegistration_WhenValid_ReturnsConfirm() throws Exception {
+        Department department = createDepartment(1, "Sales");
+        when(departmentService.findById(1)).thenReturn(department);
+
+        mockMvc.perform(post("/inputConfirm")
+                .param("lname", "Yamada")
+                .param("fname", "Taro")
+                .param("lkana", "ヤマダ")
+                .param("fkana", "タロウ")
+                .param("password", "pass")
+                .param("gender", "1")
+                .param("deptno", "1"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("input_confirm"))
+                .andExpect(model().attribute("department", department));
+    }
+
+    @Test
+    void saveEmployee_SavesAndReturnsComplete() throws Exception {
+        Department department = createDepartment(1, "Sales");
+        Employee mapped = new Employee();
+        Employee saved = new Employee();
+        saved.setEmpno(1);
+        when(modelMapper.map(any(EmployeeForm.class), eq(Employee.class))).thenReturn(mapped);
+        when(employeeService.saveEmployee(mapped)).thenReturn(saved);
+        when(departmentService.findById(1)).thenReturn(department);
+
+        mockMvc.perform(post("/saveEmployee")
+                .param("lname", "Yamada")
+                .param("fname", "Taro")
+                .param("lkana", "ヤマダ")
+                .param("fkana", "タロウ")
+                .param("password", "pass")
+                .param("gender", "1")
+                .param("deptno", "1"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("input_complete"))
+                .andExpect(model().attribute("department", department));
+    }
+
+    @Test
+    void deleteConfirm_ReturnsEmployeeInfo() throws Exception {
+        Employee employee = createEmployee(1, 1);
+        Department department = createDepartment(1, "Sales");
+        when(employeeService.findByEmployee(1)).thenReturn(employee);
+        when(departmentService.findById(1)).thenReturn(department);
+
+        mockMvc.perform(get("/deleteConfirm/1"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("delete_confirm"))
+                .andExpect(model().attribute("employee", employee))
+                .andExpect(model().attribute("department", department));
+    }
+
+    @Test
+    void deleteEmployee_PerformsDeleteAndReturnsComplete() throws Exception {
+        Department department = createDepartment(1, "Sales");
+        when(departmentService.findById(1)).thenReturn(department);
+
+        mockMvc.perform(post("/deleteEmployee")
+                .param("empno", "1")
+                .param("deptno", "1"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("delete_complete"))
+                .andExpect(model().attribute("department", department));
+
+        verify(employeeService).deleteEmployeeById(1);
+    }
+
+    @Test
+    void changeInput_ReturnsFormAndDepartments() throws Exception {
+        EmployeeForm form = new EmployeeForm();
+        form.setEmpno(1);
+        form.setLname("Yamada");
+        form.setFname("Taro");
+        form.setLkana("ヤマダ");
+        form.setFkana("タロウ");
+        form.setPassword("pass");
+        form.setGender(1);
+        form.setDeptno(1);
+        List<Department> departments = List.of(createDepartment(1, "Sales"));
+        when(employeeService.findByEmpNoAndCopyToEmployeeForm(eq(1), any(EmployeeForm.class))).thenReturn(form);
+        when(departmentService.findAll()).thenReturn(departments);
+
+        mockMvc.perform(get("/changeInput/1"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("change"))
+                .andExpect(model().attribute("employeeForm", form))
+                .andExpect(model().attribute("departments", departments));
+    }
+
+    @Test
+    void changeConfirm_WhenValidationFails_ReturnsChange() throws Exception {
+        List<Department> departments = List.of(createDepartment(1, "Sales"));
+        when(departmentService.findAll()).thenReturn(departments);
+
+        mockMvc.perform(post("/changeConfirm")
+                .param("lname", "")
+                .param("fname", "Taro")
+                .param("lkana", "ヤマダ")
+                .param("fkana", "タロウ")
+                .param("password", "pass")
+                .param("gender", "1")
+                .param("deptno", "1"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("change"))
+                .andExpect(model().attribute("departments", departments));
+    }
+
+    @Test
+    void changeConfirm_WhenValid_ReturnsConfirm() throws Exception {
+        Department department = createDepartment(1, "Sales");
+        when(departmentService.findById(1)).thenReturn(department);
+
+        mockMvc.perform(post("/changeConfirm")
+                .param("lname", "Yamada")
+                .param("fname", "Taro")
+                .param("lkana", "ヤマダ")
+                .param("fkana", "タロウ")
+                .param("password", "pass")
+                .param("gender", "1")
+                .param("deptno", "1"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("change_confirm"))
+                .andExpect(model().attribute("department", department));
+    }
+
+    @Test
+    void changeEmployee_UpdatesAndReturnsComplete() throws Exception {
+        Department department = createDepartment(1, "Sales");
+        Employee mapped = new Employee();
+        Employee saved = new Employee();
+        saved.setEmpno(1);
+        when(modelMapper.map(any(EmployeeForm.class), eq(Employee.class))).thenReturn(mapped);
+        when(employeeService.saveEmployee(mapped)).thenReturn(saved);
+        when(departmentService.findById(1)).thenReturn(department);
+
+        mockMvc.perform(post("/changeEmployee")
+                .param("empno", "1")
+                .param("lname", "Yamada")
+                .param("fname", "Taro")
+                .param("lkana", "ヤマダ")
+                .param("fkana", "タロウ")
+                .param("password", "pass")
+                .param("gender", "1")
+                .param("deptno", "1"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("change_complete"))
+                .andExpect(model().attribute("department", department));
+    }
+}

--- a/EIMS_SpringBoot/src/test/java/jp/co/trainocate/eims/controller/EmployeeControllerTest.java
+++ b/EIMS_SpringBoot/src/test/java/jp/co/trainocate/eims/controller/EmployeeControllerTest.java
@@ -1,295 +1,365 @@
 package jp.co.trainocate.eims.controller;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+import static org.hamcrest.Matchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.util.List;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.modelmapper.ModelMapper;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import jp.co.trainocate.eims.entity.Department;
 import jp.co.trainocate.eims.entity.Employee;
-import jp.co.trainocate.eims.form.EmployeeForm;
 import jp.co.trainocate.eims.service.DepartmentService;
 import jp.co.trainocate.eims.service.EmployeeService;
 
 @WebMvcTest(EmployeeController.class)
+@ActiveProfiles("test")
 class EmployeeControllerTest {
 
-    @Autowired
-    private MockMvc mockMvc;
+	@Autowired
+	private MockMvc mockMvc;
 
-    @MockBean
-    private EmployeeService employeeService;
+	@MockBean
+	private EmployeeService employeeService;
 
-    @MockBean
-    private DepartmentService departmentService;
+	@MockBean
+	private DepartmentService departmentService;
 
-    @MockBean
-    private ModelMapper modelMapper;
+	// --- 共通テストデータ（3件ずつ） ---
+	//(Controllerテストでも、メソッドの数が多い場合は、@BeforeEachのテストデータを使うと便利です)
+	private List<Department> deptList;
+	private List<Employee> empList;
 
-    private Department createDepartment(int deptno, String name) {
-        Department dept = new Department();
-        dept.setDeptno(deptno);
-        dept.setDeptname(name);
-        return dept;
-    }
+	@BeforeEach
+	void setUp() {
+		deptList = List.of(
+				new Department(100, "人事部"),
+				new Department(200, "経理部"),
+				new Department(300, "営業部"));
 
-    private Employee createEmployee(int empno, int deptno) {
-        Employee emp = new Employee();
-        emp.setEmpno(empno);
-        emp.setDeptno(deptno);
-        return emp;
-    }
+		empList = List.of(
+				new Employee(10001, "山田", "陽翔", "ヤマダ", "ヒナタ", "password", 1, deptList.get(0)),
+				new Employee(10002, "中田", "結衣", "タナカ", "ユイ", "password", 2, deptList.get(0)),
+				new Employee(10003, "鈴木", "大翔", "スズキ", "ヒロト", "password", 1, deptList.get(2)));
+	}
 
-    @Test
-    void index_ReturnsIndexView() throws Exception {
-        mockMvc.perform(get("/index"))
-                .andExpect(status().isOk())
-                .andExpect(view().name("index"));
-    }
+	// ---------- GET /index ----------
+	@Test
+	@DisplayName("index画面の表示：index ビューが返る")
+	void testIndex_ReturnsIndexView() throws Exception {
+		mockMvc.perform(get("/index"))
+				.andExpect(status().isOk())
+				.andExpect(view().name("index"));
+	}
 
-    @Test
-    void showSearchPage_ReturnsSearchWithDepartments() throws Exception {
-        List<Department> departments = List.of(createDepartment(1, "Sales"));
-        when(departmentService.findAll()).thenReturn(departments);
+	// ---------- GET /search ----------
+	@Test
+	@DisplayName("検索画面の表示：部門リストをモデルに詰めて search を返す")
+	void testShowSearchPage_ReturnsSearchWithDepartments() throws Exception {
+		Mockito.when(departmentService.findAll()).thenReturn(deptList);
 
-        mockMvc.perform(get("/search"))
-                .andExpect(status().isOk())
-                .andExpect(view().name("search"))
-                .andExpect(model().attribute("departments", departments));
-    }
+		mockMvc.perform(get("/search"))
+				.andExpect(status().isOk())
+				.andExpect(view().name("search"))
+				.andExpect(model().attributeExists("departments"))
+				.andExpect(model().attribute("departments", hasSize(3)));
 
-    @Test
-    void selectByEmpNo_WithParam_ReturnsResult() throws Exception {
-        List<Employee> employees = List.of(createEmployee(1, 1));
-        when(employeeService.findByEmpNo(1)).thenReturn(employees);
+	}
 
-        mockMvc.perform(get("/selectByEmpNo").param("empno", "1"))
-                .andExpect(status().isOk())
-                .andExpect(view().name("search_result"))
-                .andExpect(model().attribute("employees", employees));
-    }
+	// ---------- GET /selectByEmpNo?empno=10001 ----------
+	@Test
+	@DisplayName("社員番号検索（パラメータあり）：結果を search_result に表示")
+	void testSelectByEmpNo_WithParam_ReturnsResult() throws Exception {
+		List<Employee> mockEmployee = List.of(
+				new Employee(10001, "山田", "陽翔", "ヤマダ", "ヒナタ", "password", 1, deptList.get(0)));
+		Mockito.when(employeeService.findByEmpNo(10001)).thenReturn(mockEmployee);
+		mockMvc.perform(get("/selectByEmpNo").param("empno", "10001"))
+				.andExpect(status().isOk())
+				.andExpect(view().name("search_result"))
+				.andExpect(model().attributeExists("employees"))
+				.andExpect(model().attribute("employees", hasSize(1)));
 
-    @Test
-    void selectByEmpNo_NoParam_ReturnsSearch() throws Exception {
-        mockMvc.perform(get("/selectByEmpNo"))
-                .andExpect(status().isOk())
-                .andExpect(view().name("search"));
-    }
+	}
 
-    @Test
-    void selectByEmpName_ReturnsResult() throws Exception {
-        List<Employee> employees = List.of(createEmployee(1, 1));
-        when(employeeService.findByEmpName("foo")).thenReturn(employees);
+	// ---------- GET /selectByEmpNo（パラメータ無し） ----------
+	@Test
+	@DisplayName("社員番号検索（パラメータ無し）：検索画面に戻る")
+	void testSelectByEmpNo_NoParam_ReturnsSearch() throws Exception {
+		mockMvc.perform(get("/selectByEmpNo"))
+				.andExpect(status().isOk())
+				.andExpect(view().name("search"));
+	}
 
-        mockMvc.perform(get("/selectByEmpName").param("keyword", "foo"))
-                .andExpect(status().isOk())
-                .andExpect(view().name("search_result"))
-                .andExpect(model().attribute("employees", employees));
-    }
+	// ---------- GET /selectByEmpName?keyword=結衣 ----------
+	@Test
+	@DisplayName("氏名キーワード検索：「田」の検索結果を search_result に表示")
+	void testSelectByEmpName_ReturnsResult() throws Exception {
+		Mockito.when(employeeService.findByEmpName("田")).thenReturn(empList);
 
-    @Test
-    void selectByDeptNo_ReturnsResult() throws Exception {
-        List<Employee> employees = List.of(createEmployee(1, 1));
-        when(employeeService.findByDeptNo(1)).thenReturn(employees);
+		mockMvc.perform(get("/selectByEmpName").param("keyword", "田"))
+				.andExpect(status().isOk())
+				.andExpect(view().name("search_result"))
+				.andExpect(model().attributeExists("employees"))
+				.andExpect(model().attribute("employees", hasSize(2)));
 
-        mockMvc.perform(get("/selectByDeptNo").param("deptno", "1"))
-                .andExpect(status().isOk())
-                .andExpect(view().name("search_result"))
-                .andExpect(model().attribute("employees", employees));
-    }
+	}
 
-    @Test
-    void showInputPage_ReturnsInputWithDepartments() throws Exception {
-        List<Department> departments = List.of(createDepartment(1, "Sales"));
-        when(departmentService.findAll()).thenReturn(departments);
+	// ---------- GET /selectByDeptNo?deptno=100 ----------
+	@Test
+	@DisplayName("部門番号検索：結果を search_result に表示（件数も検証）")
+	void testSelectByDeptNo_ReturnsResult() throws Exception {
+		List<Employee> mockEmployee = List.of(
+				new Employee(10001, "山田", "陽翔", "ヤマダ", "ヒナタ", "password", 1, deptList.get(0)),
+				new Employee(10002, "中田", "結衣", "タナカ", "ユイ", "password", 2, deptList.get(0)));
+		Mockito.when(employeeService.findByDeptNo(100)).thenReturn(mockEmployee);
 
-        mockMvc.perform(get("/input"))
-                .andExpect(status().isOk())
-                .andExpect(view().name("input"))
-                .andExpect(model().attribute("departments", departments));
-    }
+		mockMvc.perform(get("/selectByDeptNo").param("deptno", "100"))
+				.andExpect(status().isOk())
+				.andExpect(view().name("search_result"))
+				.andExpect(model().attributeExists("employees"))
+				.andExpect(model().attribute("employees", hasSize(2)));
+	}
 
-    @Test
-    void confirmRegistration_WhenValidationFails_ReturnsInput() throws Exception {
-        List<Department> departments = List.of(createDepartment(1, "Sales"));
-        when(departmentService.findAll()).thenReturn(departments);
+	// ---------- GET /input ----------
+	@Test
+	@DisplayName("登録画面の表示：部門リストありで input を返す")
+	void testShowInputPage_ReturnsInputWithDepartments() throws Exception {
+		Mockito.when(departmentService.findAll()).thenReturn(deptList);
 
-        mockMvc.perform(post("/inputConfirm")
-                .param("lname", "")
-                .param("fname", "Taro")
-                .param("lkana", "ヤマダ")
-                .param("fkana", "タロウ")
-                .param("password", "pass")
-                .param("gender", "1")
-                .param("deptno", "1"))
-                .andExpect(status().isOk())
-                .andExpect(view().name("input"))
-                .andExpect(model().attribute("departments", departments));
-    }
+		mockMvc.perform(get("/input"))
+				.andExpect(status().isOk())
+				.andExpect(view().name("input"))
+				.andExpect(model().attributeExists("departments"))
+				.andExpect(model().attribute("departments", hasSize(3)));
+	}
 
-    @Test
-    void confirmRegistration_WhenValid_ReturnsConfirm() throws Exception {
-        Department department = createDepartment(1, "Sales");
-        when(departmentService.findById(1)).thenReturn(department);
+	// ---------- POST /inputConfirm（正常系） ----------
+	@Test
+	@DisplayName("登録確認(正常系)：バリデーションOKで input_confirm を返す（選択部門をモデルへ）")
+	void testConfirmRegistration_WhenValid_ReturnsConfirm() throws Exception {
+		Mockito.when(departmentService.findById(100)).thenReturn(deptList.get(0));
 
-        mockMvc.perform(post("/inputConfirm")
-                .param("lname", "Yamada")
-                .param("fname", "Taro")
-                .param("lkana", "ヤマダ")
-                .param("fkana", "タロウ")
-                .param("password", "pass")
-                .param("gender", "1")
-                .param("deptno", "1"))
-                .andExpect(status().isOk())
-                .andExpect(view().name("input_confirm"))
-                .andExpect(model().attribute("department", department));
-    }
+		mockMvc.perform(post("/inputConfirm")
+				.param("lname", "山田")
+				.param("fname", "太郎")
+				.param("lkana", "ヤマダ")
+				.param("fkana", "タロウ")
+				.param("password", "passwords")
+				.param("gender", "1")
+				.param("deptno", "100"))
+				.andExpect(status().isOk())
+				.andExpect(view().name("input_confirm"))
+				.andExpect(model().attributeExists("department"))
+				.andExpect(model().attribute("department", hasProperty("deptname",
+						is("人事部"))));
 
-    @Test
-    void saveEmployee_SavesAndReturnsComplete() throws Exception {
-        Department department = createDepartment(1, "Sales");
-        Employee mapped = new Employee();
-        Employee saved = new Employee();
-        saved.setEmpno(1);
-        when(modelMapper.map(any(EmployeeForm.class), eq(Employee.class))).thenReturn(mapped);
-        when(employeeService.saveEmployee(mapped)).thenReturn(saved);
-        when(departmentService.findById(1)).thenReturn(department);
+	}
 
-        mockMvc.perform(post("/saveEmployee")
-                .param("lname", "Yamada")
-                .param("fname", "Taro")
-                .param("lkana", "ヤマダ")
-                .param("fkana", "タロウ")
-                .param("password", "pass")
-                .param("gender", "1")
-                .param("deptno", "1"))
-                .andExpect(status().isOk())
-                .andExpect(view().name("input_complete"))
-                .andExpect(model().attribute("department", department));
-    }
+	// ---------- POST /inputConfirm（NotNull&NotBlankバリデーションNG） ----------
+	@Test
+	@DisplayName("登録確認(異常系➀)：NotNull&NotBlankバリデーションNGで input に戻る（部門リスト存在）")
+	void testConfirmRegistration_WhenValidationFails1_ReturnsInput() throws Exception {
 
-    @Test
-    void deleteConfirm_ReturnsEmployeeInfo() throws Exception {
-        Employee employee = createEmployee(1, 1);
-        Department department = createDepartment(1, "Sales");
-        when(employeeService.findByEmployee(1)).thenReturn(employee);
-        when(departmentService.findById(1)).thenReturn(department);
+		mockMvc.perform(post("/inputConfirm")
+				.param("lname", "")
+				.param("fname", "")
+				.param("lkana", "")
+				.param("fkana", "")
+				.param("password", "")
+				.param("gender", "")
+				.param("deptno", ""))
+				.andExpect(status().isOk())
+				.andExpect(view().name("input"))
+				.andExpect(model().attributeExists("departments"))
+				.andExpect(model().attributeHasFieldErrors(
+						"employeeForm", "lname", "fname", "lkana", "password", "gender", "deptno"));
 
-        mockMvc.perform(get("/deleteConfirm/1"))
-                .andExpect(status().isOk())
-                .andExpect(view().name("delete_confirm"))
-                .andExpect(model().attribute("employee", employee))
-                .andExpect(model().attribute("department", department));
-    }
+	}
 
-    @Test
-    void deleteEmployee_PerformsDeleteAndReturnsComplete() throws Exception {
-        Department department = createDepartment(1, "Sales");
-        when(departmentService.findById(1)).thenReturn(department);
+	// ---------- POST /inputConfirm（その他バリデーションNG） ----------
+	@Test
+	@DisplayName("登録確認(異常系➁)：その他バリデーションNGで input に戻る（部門リスト存在）")
+	void testConfirmRegistration_WhenValidationFails2_ReturnsInput() throws Exception {
 
-        mockMvc.perform(post("/deleteEmployee")
-                .param("empno", "1")
-                .param("deptno", "1"))
-                .andExpect(status().isOk())
-                .andExpect(view().name("delete_complete"))
-                .andExpect(model().attribute("department", department));
+		mockMvc.perform(post("/inputConfirm")
+				.param("lname", "氏".repeat(11))// 11文字で違反
+				.param("fname", "名".repeat(11))// 11文字で違反
+				.param("lkana", "し".repeat(11))// 11文字で違反
+				.param("fkana", "め".repeat(11))// 11文字で違反
+				.param("password", "p".repeat(7)) // 7文字で違反
+				.param("gender", "1") //正常
+				.param("deptno", "100")) //正常
+				.andExpect(status().isOk())
+				.andExpect(view().name("input"))
+				.andExpect(model().attributeExists("departments"))
+				.andExpect(model().attributeHasFieldErrors(
+						"employeeForm", "lname", "fname", "lkana", "password"));
 
-        verify(employeeService).deleteEmployeeById(1);
-    }
+	}
 
-    @Test
-    void changeInput_ReturnsFormAndDepartments() throws Exception {
-        EmployeeForm form = new EmployeeForm();
-        form.setEmpno(1);
-        form.setLname("Yamada");
-        form.setFname("Taro");
-        form.setLkana("ヤマダ");
-        form.setFkana("タロウ");
-        form.setPassword("pass");
-        form.setGender(1);
-        form.setDeptno(1);
-        List<Department> departments = List.of(createDepartment(1, "Sales"));
-        when(employeeService.findByEmpNoAndCopyToEmployeeForm(eq(1), any(EmployeeForm.class))).thenReturn(form);
-        when(departmentService.findAll()).thenReturn(departments);
+	// ---------- POST /saveEmployee ----------
+	@Test
+	@DisplayName("登録実行：保存して input_complete を返す（ModelMapper不使用）")
+	void testSaveEmployee_SavesAndReturnsComplete() throws Exception {
+		Mockito.when(departmentService.findById(100)).thenReturn(deptList.get(0));
 
-        mockMvc.perform(get("/changeInput/1"))
-                .andExpect(status().isOk())
-                .andExpect(view().name("change"))
-                .andExpect(model().attribute("employeeForm", form))
-                .andExpect(model().attribute("departments", departments));
-    }
+		mockMvc.perform(post("/saveEmployee")
+				.param("lname", "山田")
+				.param("fname", "太郎")
+				.param("lkana", "ヤマダ")
+				.param("fkana", "タロウ")
+				.param("password", "passwords")
+				.param("gender", "1")
+				.param("deptno", "100"))
+				.andExpect(status().isOk())
+				.andExpect(view().name("input_complete"))
+				.andExpect(model().attributeExists("department"))
+				.andExpect(model().attribute("department", hasProperty("deptname",
+						is("人事部"))));
 
-    @Test
-    void changeConfirm_WhenValidationFails_ReturnsChange() throws Exception {
-        List<Department> departments = List.of(createDepartment(1, "Sales"));
-        when(departmentService.findAll()).thenReturn(departments);
+	}
 
-        mockMvc.perform(post("/changeConfirm")
-                .param("lname", "")
-                .param("fname", "Taro")
-                .param("lkana", "ヤマダ")
-                .param("fkana", "タロウ")
-                .param("password", "pass")
-                .param("gender", "1")
-                .param("deptno", "1"))
-                .andExpect(status().isOk())
-                .andExpect(view().name("change"))
-                .andExpect(model().attribute("departments", departments));
-    }
+	// ---------- GET /deleteConfirm/{empno} ----------
+	@Test
+	@DisplayName("削除確認：社員情報と部門情報を表示")
+	void testDeleteConfirm_ReturnsEmployeeInfo() throws Exception {
+		Mockito.when(employeeService.findByEmployee(10001)).thenReturn(empList.get(0));
 
-    @Test
-    void changeConfirm_WhenValid_ReturnsConfirm() throws Exception {
-        Department department = createDepartment(1, "Sales");
-        when(departmentService.findById(1)).thenReturn(department);
+		mockMvc.perform(get("/deleteConfirm/10001"))
+				.andExpect(status().isOk())
+				.andExpect(view().name("delete_confirm"))
+				.andExpect(model().attributeExists("employee"))
+				.andExpect(model().attribute("employee", hasProperty("empno", is(10001))));
+	}
 
-        mockMvc.perform(post("/changeConfirm")
-                .param("lname", "Yamada")
-                .param("fname", "Taro")
-                .param("lkana", "ヤマダ")
-                .param("fkana", "タロウ")
-                .param("password", "pass")
-                .param("gender", "1")
-                .param("deptno", "1"))
-                .andExpect(status().isOk())
-                .andExpect(view().name("change_confirm"))
-                .andExpect(model().attribute("department", department));
-    }
+	// ---------- POST /deleteEmployee ----------
+	@Test
+	@DisplayName("削除実行：削除して delete_complete を返す")
+	void testDeleteEmployee_PerformsDeleteAndReturnsComplete() throws Exception {
+		Mockito.when(employeeService.findByEmployee(10001)).thenReturn(empList.get(0));
 
-    @Test
-    void changeEmployee_UpdatesAndReturnsComplete() throws Exception {
-        Department department = createDepartment(1, "Sales");
-        Employee mapped = new Employee();
-        Employee saved = new Employee();
-        saved.setEmpno(1);
-        when(modelMapper.map(any(EmployeeForm.class), eq(Employee.class))).thenReturn(mapped);
-        when(employeeService.saveEmployee(mapped)).thenReturn(saved);
-        when(departmentService.findById(1)).thenReturn(department);
+		mockMvc.perform(post("/deleteEmployee")
+				.param("empno", "10001")
+				.param("lname", "山田")
+				.param("fname", "太郎")
+				.param("lkana", "ヤマダ")
+				.param("fkana", "タロウ")
+				.param("password", "passwords")
+				.param("gender", "1")
+				.param("deptno", "100"))
+				.andExpect(status().isOk())
+				.andExpect(view().name("delete_complete"))
+				.andExpect(model().attributeExists("employee"))
+				.andExpect(model().attribute("employee", hasProperty("empno", is(10001))));
 
-        mockMvc.perform(post("/changeEmployee")
-                .param("empno", "1")
-                .param("lname", "Yamada")
-                .param("fname", "Taro")
-                .param("lkana", "ヤマダ")
-                .param("fkana", "タロウ")
-                .param("password", "pass")
-                .param("gender", "1")
-                .param("deptno", "1"))
-                .andExpect(status().isOk())
-                .andExpect(view().name("change_complete"))
-                .andExpect(model().attribute("department", department));
-    }
+	}
+
+	// ---------- GET /changeInput/{empno} ----------
+	@Test
+	@DisplayName("変更画面表示：フォーム値と部門リストをモデルに詰める")
+	void testChangeInput_ReturnsFormAndDepartments() throws Exception {
+
+		Mockito.when(departmentService.findAll()).thenReturn(deptList);
+
+		mockMvc.perform(get("/changeInput/10001"))
+				.andExpect(status().isOk())
+				.andExpect(view().name("change"))
+				.andExpect(model().attributeExists("employeeForm", "departments"))
+				.andExpect(model().attribute("departments", hasSize(3)));
+
+	}
+
+	// ---------- POST /changeConfirm（バリデーションOK） ----------
+	@Test
+	@DisplayName("変更確認(正常系)：バリデーションOKで change_confirm を返す（選択部門をモデルへ）")
+	void testChangeConfirm_WhenValid_ReturnsConfirm() throws Exception {
+		when(departmentService.findById(100)).thenReturn(deptList.get(0));
+
+		mockMvc.perform(post("/changeConfirm")
+				.param("empno", "10001")
+				.param("lname", "山田")
+				.param("fname", "太郎")
+				.param("lkana", "ヤマダ")
+				.param("fkana", "タロウ")
+				.param("password", "passwords")
+				.param("gender", "1")
+				.param("deptno", "100"))
+				.andExpect(status().isOk())
+				.andExpect(view().name("change_confirm"))
+				.andExpect(model().attributeExists("department"))
+				.andExpect(model().attribute("department", hasProperty("deptname",
+						is("人事部"))));
+	}
+
+	// ---------- POST /changeConfirm（バリデーションNG） ----------
+	@Test
+	@DisplayName("変更確認(異常系➀)：NotNull&NotBlankバリデーションNGで change に戻る（部門リスト存在）")
+	void testChangeConfirm_WhenValidationFails1_ReturnsChange() throws Exception {
+
+		mockMvc.perform(post("/changeConfirm")
+				.param("lname", "")
+				.param("fname", "")
+				.param("lkana", "")
+				.param("fkana", "")
+				.param("password", "")
+				.param("gender", "")
+				.param("deptno", ""))
+				.andExpect(status().isOk())
+				.andExpect(view().name("change"))
+				.andExpect(model().attributeExists("departments"))
+				.andExpect(model().attributeHasFieldErrors(
+						"employeeForm", "lname", "fname", "lkana", "password", "gender", "deptno"));
+	}
+
+	// ---------- POST /changeConfirm（バリデーションNG） ----------
+	@Test
+	@DisplayName("変更確認(異常系➁)：その他バリデーションNGで change に戻る（部門リスト存在）")
+	void testChangeConfirm_WhenValidationFails2_ReturnsChange() throws Exception {
+
+		mockMvc.perform(post("/changeConfirm")
+				.param("lname", "氏".repeat(11))// 11文字で違反
+				.param("fname", "名".repeat(11))// 11文字で違反
+				.param("lkana", "し".repeat(11))// 11文字で違反
+				.param("fkana", "め".repeat(11))// 11文字で違反
+				.param("password", "p".repeat(7)) // 7文字で違反
+				.param("gender", "1") //正常
+				.param("deptno", "100")) //正常
+				.andExpect(status().isOk())
+				.andExpect(view().name("change"))
+				.andExpect(model().attributeExists("departments"))
+				.andExpect(model().attributeHasFieldErrors(
+						"employeeForm", "lname", "fname", "lkana", "password"));
+	}
+
+	// ---------- POST /changeEmployee ----------
+	@Test
+	@DisplayName("変更実行：保存して change_complete を返す（ModelMapper不使用）")
+	void testChangeEmployee_UpdatesAndReturnsComplete() throws Exception {
+		Mockito.when(departmentService.findById(100)).thenReturn(deptList.get(0));
+
+		mockMvc.perform(post("/changeEmployee")
+				.param("empno", "10001")
+				.param("lname", "山田")
+				.param("fname", "太郎")
+				.param("lkana", "ヤマダ")
+				.param("fkana", "タロウ")
+				.param("password", "passwords")
+				.param("gender", "1")
+				.param("deptno", "100"))
+				.andExpect(status().isOk())
+				.andExpect(view().name("change_complete"))
+				.andExpect(model().attributeExists("department"))
+				.andExpect(model().attribute("department", hasProperty("deptno", is(100))));
+
+	}
 }

--- a/EIMS_SpringBoot/src/test/java/jp/co/trainocate/eims/repository/EmployeeRepositoryTest.java
+++ b/EIMS_SpringBoot/src/test/java/jp/co/trainocate/eims/repository/EmployeeRepositoryTest.java
@@ -1,0 +1,76 @@
+package jp.co.trainocate.eims.repository;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import jp.co.trainocate.eims.entity.Department;
+import jp.co.trainocate.eims.entity.Employee;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+
+class EmployeeRepositoryTest {
+
+	@Autowired
+	private EmployeeRepository empRepo;
+
+	@Autowired
+	private DepartmentRepository deptRepo;
+
+	Employee emp1;
+	Employee emp2;
+	Employee emp3;
+	
+	// --- 共通テストデータ（3件ずつ） ---
+	@BeforeEach
+	void setUp() {
+		// 既存データを削除してリセット
+		empRepo.deleteAll();
+		deptRepo.deleteAll();
+
+		// カテゴリを作成
+		Department jinji = new Department();
+		jinji.setDeptno(110);
+		jinji.setDeptname("人事部");
+		
+		Department keiri = new Department();
+		jinji.setDeptno(120);
+		jinji.setDeptname("経理部");
+		
+		
+		emp1 = empRepo.save(new Employee("山田", "陽翔", "ヤマダ", "ヒナタ", "password", 1, jinji.getDeptno()));
+		emp2 = empRepo.save(new Employee("中田", "結衣", "タナカ", "ユイ", "password", 2, keiri.getDeptno()));
+		emp3 = empRepo.save(new Employee("鈴木", "大翔", "スズキ", "ヒロト", "password", 1, jinji.getDeptno()));
+
+	}
+
+	@Test
+	void testFindByEmpno() {
+		List<Employee> result = empRepo.findByempno(emp1.getEmpno());
+		assertThat(result).hasSize(1);
+		assertThat(result.get(0).getLname()).isEqualTo("山田");
+	}
+	
+	@Test
+	void testFindByEmpNameLike() {
+		List<Employee> result = empRepo.findByEmpNameLike("田");
+		assertThat(result).hasSize(2);
+		assertThat(result).extracting(Employee::getLname).containsExactlyInAnyOrder("山田","中田");
+	}
+	
+	/*@Test
+	void testFindByDepartmentDeptno() {
+		List<Employee> result = empRepo.findByDepartmentDeptno(110);
+		assertThat(result).hasSize(2);
+		assertThat(result.get(0).getLname()).isEqualTo("山田");
+		assertThat(result.get(0).getDeptno()).isEqualTo(110);
+	}*/
+}

--- a/EIMS_SpringBoot/src/test/java/jp/co/trainocate/eims/repository/EmployeeRepositoryTest.java
+++ b/EIMS_SpringBoot/src/test/java/jp/co/trainocate/eims/repository/EmployeeRepositoryTest.java
@@ -11,12 +11,16 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
+import jakarta.persistence.EntityManager;
 import jp.co.trainocate.eims.entity.Department;
 import jp.co.trainocate.eims.entity.Employee;
-
-@DataJpaTest
-@AutoConfigureTestDatabase(replace = Replace.NONE)
-
+/**
+ * EmployeeRepository の振る舞いを検証する JPA 用テストクラス。
+ * - プロファイル test の設定（application-test.properties）で MySQL に接続。
+ * - 各テストはトランザクションで実行され、終了時にロールバックされる（@DataJpaTest の既定）。
+ */
+@DataJpaTest // Repository/JPA の最小構成だけ起動し、DB操作をロールバック付きでテストする
+@AutoConfigureTestDatabase(replace = Replace.NONE) // 組み込みDBへ差し替えず、プロパティの実DB設定をそのまま使う
 class EmployeeRepositoryTest {
 
 	@Autowired
@@ -24,53 +28,94 @@ class EmployeeRepositoryTest {
 
 	@Autowired
 	private DepartmentRepository deptRepo;
-
+	
+	@Autowired 
+	private EntityManager entityManager; // ネイティブSQL実行（AUTO_INCREMENT リセット等）に使用
+	
+	// 各テストで参照するための共有フィールド
 	Employee emp1;
 	Employee emp2;
 	Employee emp3;
 	
-	// --- 共通テストデータ（3件ずつ） ---
+	/**
+	 * 各テスト前に、テーブル初期化 → 部署マスタ投入 → 社員データ投入、の順で準備する。
+	 */
 	@BeforeEach
 	void setUp() {
-		// 既存データを削除してリセット
-		empRepo.deleteAll();
-		deptRepo.deleteAll();
+	    // 1) 既存データを削除（依存関係の都合で子→親の順で削除）
+	    empRepo.deleteAll();
+	    deptRepo.deleteAll();
+	    
+	    // 2) 主キーの採番を 1 からに戻す（MySQL は DDL が暗黙コミットされる点に注意）
+	    entityManager.createNativeQuery("ALTER TABLE employee AUTO_INCREMENT = 1").executeUpdate();
 
-		// カテゴリを作成
-		Department jinji = new Department();
-		jinji.setDeptno(110);
-		jinji.setDeptname("人事部");
-		
-		Department keiri = new Department();
-		jinji.setDeptno(120);
-		jinji.setDeptname("経理部");
-		
-		
-		emp1 = empRepo.save(new Employee("山田", "陽翔", "ヤマダ", "ヒナタ", "password", 1, jinji.getDeptno()));
-		emp2 = empRepo.save(new Employee("中田", "結衣", "タナカ", "ユイ", "password", 2, keiri.getDeptno()));
-		emp3 = empRepo.save(new Employee("鈴木", "大翔", "スズキ", "ヒロト", "password", 1, jinji.getDeptno()));
+	    // 3) 部署マスタを登録（手動採番）
+	    Department jinji  = deptRepo.save(new Department(110, "人事部"));
+	    Department keiri  = deptRepo.save(new Department(120, "経理部"));
 
+	    // 4) 社員エンティティを作成・保存
+	    // 本エンティティは、@ManyToOne Department と 整数FK deptno の二重マッピングを持つ想定。
+	    // → department をセットしたら、整合のため deptno も同期させておく。
+	    emp1 = new Employee();
+	    emp1.setLname("山田"); emp1.setFname("陽翔");
+	    emp1.setLkana("ヤマダ"); emp1.setFkana("ヒナタ");
+	    emp1.setPassword("password"); emp1.setGender(1);
+	    emp1.setDepartment(jinji);
+	    emp1.setDeptno(jinji.getDeptno());
+	    emp1 = empRepo.save(emp1); // save の戻り値はIDが確定した最新状態
+
+	    emp2 = new Employee();
+	    emp2.setLname("中田"); emp2.setFname("結衣");
+	    emp2.setLkana("ナカタ"); emp2.setFkana("ユイ");
+	    emp2.setPassword("password"); emp2.setGender(2);
+	    emp2.setDepartment(keiri);
+	    emp2.setDeptno(keiri.getDeptno());
+	    emp2 = empRepo.save(emp2);
+
+	    emp3 = new Employee();
+	    emp3.setLname("鈴木"); emp3.setFname("大翔");
+	    emp3.setLkana("スズキ"); emp3.setFkana("ヒロト");
+	    emp3.setPassword("password"); emp3.setGender(1);
+	    emp3.setDepartment(jinji);
+	    emp3.setDeptno(jinji.getDeptno());
+	    emp3 = empRepo.save(emp3);
 	}
 
+	/**
+	 * 社員番号（主キー）での検索が 1 件ヒットすることを検証。
+	 */
 	@Test
 	void testFindByEmpno() {
+		// 1) 実行
 		List<Employee> result = empRepo.findByempno(emp1.getEmpno());
+		// 2) 件数検証
 		assertThat(result).hasSize(1);
+		// 3) 内容検証
 		assertThat(result.get(0).getLname()).isEqualTo("山田");
 	}
 	
+	/**
+	 * 氏名の部分一致検索（姓/名/カナ）で「田」を含む社員が 2 名ヒットすることを検証。
+	 * Repository 側は JPQL + LIKEで実装している前提。
+	 */
 	@Test
 	void testFindByEmpNameLike() {
 		List<Employee> result = empRepo.findByEmpNameLike("田");
 		assertThat(result).hasSize(2);
+		// 取得順は未保証のため、順序非依存で比較
 		assertThat(result).extracting(Employee::getLname).containsExactlyInAnyOrder("山田","中田");
 	}
 	
-	/*@Test
+	/**
+	 * 部署番号での検索が 2 件ヒットすることを検証。
+	 * ※ 取得順はDB/実装に依存して未保証。実務では順序前提の検証は避けるのが無難。
+	 */
+	@Test
 	void testFindByDepartmentDeptno() {
 		List<Employee> result = empRepo.findByDepartmentDeptno(110);
 		assertThat(result).hasSize(2);
+		// ここでは例として先頭要素を簡易チェック（厳密さが必要なら順序を指定して検索する/順序非依存の検証にする）
 		assertThat(result.get(0).getLname()).isEqualTo("山田");
 		assertThat(result.get(0).getDeptno()).isEqualTo(110);
-	}*/
+	}
 }

--- a/EIMS_SpringBoot/src/test/resources/application-test.properties
+++ b/EIMS_SpringBoot/src/test/resources/application-test.properties
@@ -3,4 +3,4 @@ spring.thymeleaf.cache=false
 
 spring.datasource.url=jdbc:mysql://localhost/eimsdb_test?serverTimezone=Asia/Tokyo
 spring.datasource.username=eimsuser_test
-spring.datasource.password=eimspass_test
+spring.datasource.password=eimspass

--- a/EIMS_SpringBoot/src/test/resources/application-test.properties
+++ b/EIMS_SpringBoot/src/test/resources/application-test.properties
@@ -1,0 +1,7 @@
+spring.thymeleaf.cache=false
+
+spring.datasource.url=jdbc:mysql://localhost/eimsdb_test?serverTimezone=Asia/Tokyo
+spring.datasource.username=eimsuser
+spring.datasource.password=eimspass
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true

--- a/EIMS_SpringBoot/src/test/resources/application-test.properties
+++ b/EIMS_SpringBoot/src/test/resources/application-test.properties
@@ -1,7 +1,6 @@
 spring.thymeleaf.cache=false
 
+
 spring.datasource.url=jdbc:mysql://localhost/eimsdb_test?serverTimezone=Asia/Tokyo
-spring.datasource.username=eimsuser
-spring.datasource.password=eimspass
-spring.jpa.hibernate.ddl-auto=update
-spring.jpa.show-sql=true
+spring.datasource.username=eimsuser_test
+spring.datasource.password=eimspass_test


### PR DESCRIPTION
## Summary
- add `EmployeeControllerTest` with `@WebMvcTest` verifying index, search, registration, save, delete, and change endpoints

## Testing
- `./mvnw test` *(fails: Non-resolvable parent POM: Could not transfer artifact: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6896f1e578b88321933022da80e2a375